### PR TITLE
Add WordPress e-commerce header plugin

### DIFF
--- a/ecommerce-header/README.md
+++ b/ecommerce-header/README.md
@@ -1,0 +1,39 @@
+# E-commerce Header Suite
+
+Plugin de WordPress que añade un encabezado moderno pensado para tiendas en línea. Incluye barra superior con mensaje promocional, logotipo, buscador, botón principal configurable, enlace a la cuenta, resumen de carrito y menú adaptable con control móvil.
+
+## Características
+
+- Registro de ubicación de menú específica para el encabezado.
+- Panel de ajustes bajo **Apariencia → Encabezado E-commerce** para personalizar logo, CTA, mensaje informativo y visibilidad de cada elemento.
+- Estilos responsive listos para dispositivos móviles.
+- Botón hamburguesa con JavaScript ligero para mostrar/ocultar el menú en pantallas pequeñas.
+- Integración con WooCommerce para mostrar la cantidad de productos en el carrito y actualizarla tras añadir productos mediante AJAX.
+
+## Instalación
+
+1. Copia la carpeta `ecommerce-header` dentro de `wp-content/plugins/`.
+2. Activa **E-commerce Header Suite** desde el panel de *Plugins* en WordPress.
+3. Dirígete a **Apariencia → Encabezado E-commerce** para personalizar los elementos.
+4. Asigna un menú al nuevo espacio **Menú encabezado e-commerce** en **Apariencia → Menús**.
+
+## Personalización rápida
+
+- **Logo**: introduce la URL de la imagen (puedes usar la biblioteca de medios de WordPress).
+- **Botón principal**: establece el texto y la URL que apuntará a tus promociones o categorías más rentables.
+- **Mensaje superior**: comparte beneficios de envío, horarios o contacto.
+- **Elementos opcionales**: activa o desactiva buscador, enlace de cuenta y resumen de carrito según las necesidades de tu tienda.
+
+## Hooks personalizados
+
+- **Evento JS** `echp-refresh-cart`: lanza este evento en `document` para forzar la actualización de la burbuja del carrito desde código personalizado.
+
+## Compatibilidad
+
+- Compatible con WooCommerce.
+- Fallback para temas sin `wp_body_open`, inyectando el encabezado antes del pie de página.
+- Incluye estilos y scripts autónomos para evitar conflictos.
+
+## Desarrollo
+
+Los estilos principales se encuentran en `assets/css/header.css` y el comportamiento en `assets/js/header.js`. Puedes ejecutar `npm` o tu preprocesador favorito para ampliar o minificar estos archivos.

--- a/ecommerce-header/assets/css/header.css
+++ b/ecommerce-header/assets/css/header.css
@@ -1,0 +1,332 @@
+:root {
+    --echp-primary: #1a73e8;
+    --echp-text: #1f2933;
+    --echp-muted: #6b7280;
+    --echp-border: #e5e7eb;
+    --echp-background: #ffffff;
+    --echp-topbar-bg: #0f172a;
+    --echp-topbar-text: #f8fafc;
+}
+
+.echp-header {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--echp-background);
+    color: var(--echp-text);
+    border-bottom: 1px solid var(--echp-border);
+    box-shadow: 0 2px 6px rgba(15, 23, 42, 0.05);
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    z-index: 999;
+}
+
+.echp-top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.35rem 1.5rem;
+    background: var(--echp-topbar-bg);
+    color: var(--echp-topbar-text);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.screen-reader-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.echp-top-bar a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.echp-support-text {
+    font-weight: 500;
+    letter-spacing: 0.04em;
+}
+
+.echp-account-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.echp-main-bar {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+}
+
+.echp-branding {
+    display: flex;
+    align-items: center;
+}
+
+.echp-logo img {
+    max-height: 52px;
+    width: auto;
+    display: block;
+}
+
+.echp-site-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--echp-text);
+    text-decoration: none;
+}
+
+.echp-search {
+    max-width: 560px;
+    width: 100%;
+}
+
+.echp-search form {
+    display: flex;
+    align-items: center;
+    background: #f8fafc;
+    border: 1px solid var(--echp-border);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+}
+
+.echp-search input[type="search"] {
+    flex: 1;
+    border: none;
+    background: transparent;
+    outline: none;
+    font-size: 0.95rem;
+    padding: 0.35rem 0.5rem;
+    color: var(--echp-text);
+}
+
+.echp-search input[type="submit"],
+.echp-search button {
+    background: none;
+    border: none;
+    color: var(--echp-muted);
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.echp-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    justify-self: end;
+}
+
+.echp-cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6rem 1.25rem;
+    border-radius: 999px;
+    background: var(--echp-primary);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease;
+    min-width: 110px;
+}
+
+.echp-cta:hover,
+.echp-cta:focus {
+    background: #0f5edc;
+    color: #fff;
+}
+
+.echp-cart {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--echp-text);
+    text-decoration: none;
+}
+
+.echp-cart-icon {
+    width: 1.35rem;
+    height: 1.35rem;
+    border: 2px solid currentColor;
+    border-radius: 4px;
+    position: relative;
+}
+
+.echp-cart-icon::after {
+    content: "";
+    position: absolute;
+    top: -0.55rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 0.9rem;
+    height: 0.45rem;
+    border: 2px solid currentColor;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+}
+
+.echp-cart-count {
+    min-width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    background: #ef4444;
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0 0.35rem;
+}
+
+.echp-menu-toggle {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border: 1px solid var(--echp-border);
+    border-radius: 999px;
+    background: #ffffff;
+    color: var(--echp-text);
+    cursor: pointer;
+}
+
+.echp-menu-toggle-icon,
+.echp-menu-toggle-icon::before,
+.echp-menu-toggle-icon::after {
+    display: block;
+    width: 1.25rem;
+    height: 2px;
+    background: currentColor;
+    border-radius: 2px;
+    position: relative;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.echp-menu-toggle-icon::before,
+.echp-menu-toggle-icon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+}
+
+.echp-menu-toggle-icon::before {
+    top: -6px;
+}
+
+.echp-menu-toggle-icon::after {
+    top: 6px;
+}
+
+.echp-menu-toggle[aria-expanded="true"] .echp-menu-toggle-icon {
+    background: transparent;
+}
+
+.echp-menu-toggle[aria-expanded="true"] .echp-menu-toggle-icon::before {
+    transform: translateY(6px) rotate(45deg);
+}
+
+.echp-menu-toggle[aria-expanded="true"] .echp-menu-toggle-icon::after {
+    transform: translateY(-6px) rotate(-45deg);
+}
+
+.echp-navigation {
+    border-top: 1px solid var(--echp-border);
+    background: #f8fafc;
+}
+
+.echp-menu {
+    display: flex;
+    gap: 1.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0.75rem 1.5rem;
+    flex-wrap: wrap;
+}
+
+.echp-menu > li > a {
+    text-decoration: none;
+    color: var(--echp-text);
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.echp-menu > li > a:hover,
+.echp-menu > li > a:focus {
+    color: var(--echp-primary);
+}
+
+@media (max-width: 980px) {
+    .echp-main-bar {
+        grid-template-columns: auto 1fr auto;
+        gap: 0.75rem;
+    }
+
+    .echp-search {
+        order: 3;
+        grid-column: 1 / -1;
+        width: 100%;
+    }
+
+    .echp-actions {
+        order: 2;
+    }
+
+    .echp-menu-toggle {
+        display: inline-flex;
+    }
+
+    .echp-navigation {
+        display: none;
+        border-top: 1px solid var(--echp-border);
+    }
+
+    .echp-navigation.is-open {
+        display: block;
+    }
+
+    .echp-menu {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .echp-menu > li {
+        border-bottom: 1px solid var(--echp-border);
+    }
+
+    .echp-menu > li > a {
+        display: block;
+        padding: 0.9rem 1.5rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .echp-top-bar {
+        flex-direction: column;
+        gap: 0.25rem;
+        text-align: center;
+    }
+
+    .echp-main-bar {
+        padding: 0.75rem 1rem;
+    }
+
+    .echp-menu {
+        padding: 0;
+    }
+}

--- a/ecommerce-header/assets/js/header.js
+++ b/ecommerce-header/assets/js/header.js
@@ -1,0 +1,84 @@
+(function () {
+    function ready(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else {
+            document.addEventListener('DOMContentLoaded', fn);
+        }
+    }
+
+    function toggleMenu() {
+        var toggle = document.querySelector('.echp-menu-toggle');
+        var nav = document.querySelector('.echp-navigation');
+
+        if (!toggle || !nav) {
+            return;
+        }
+
+        toggle.addEventListener('click', function () {
+            var isOpen = nav.classList.toggle('is-open');
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+    }
+
+    function updateCartCount(count) {
+        var el = document.querySelector('[data-echp-cart-count]');
+        if (!el) {
+            return;
+        }
+
+        el.textContent = typeof count === 'number' ? count : 0;
+    }
+
+    function requestCartCount() {
+        if (!window.echpHeader || !window.echpHeader.ajaxUrl) {
+            return;
+        }
+
+        var formData = new URLSearchParams();
+        formData.set('action', 'echp_cart_count');
+
+        fetch(window.echpHeader.ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            body: formData.toString()
+        })
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Request failed');
+                }
+                return response.json();
+            })
+            .then(function (payload) {
+                if (payload && payload.success && payload.data && typeof payload.data.count !== 'undefined') {
+                    updateCartCount(parseInt(payload.data.count, 10));
+                }
+            })
+            .catch(function () {
+                // Silently ignore failures and leave current count untouched.
+            });
+    }
+
+    function bindCartEvents() {
+        if (window.jQuery) {
+            window.jQuery(function ($) {
+                $(document.body).on('added_to_cart wc_fragments_refreshed', function () {
+                    requestCartCount();
+                });
+            });
+        }
+
+        document.addEventListener('echp-refresh-cart', function () {
+            requestCartCount();
+        });
+    }
+
+    ready(function () {
+        toggleMenu();
+        bindCartEvents();
+        requestCartCount();
+    });
+})();

--- a/ecommerce-header/ecommerce-header.php
+++ b/ecommerce-header/ecommerce-header.php
@@ -1,0 +1,449 @@
+<?php
+/**
+ * Plugin Name: E-commerce Header Suite
+ * Description: Proporciona un encabezado flexible para sitios de comercio electrónico, con búsqueda, resumen de carrito y accesos directos personalizables.
+ * Version: 1.0.0
+ * Author: Inicio Dev Team
+ * Text Domain: ecommerce-header-suite
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'ECHP_VERSION', '1.0.0' );
+define( 'ECHP_PLUGIN_FILE', __FILE__ );
+define( 'ECHP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'ECHP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+
+register_activation_hook( __FILE__, [ 'Ecommerce_Header_Plugin', 'activate' ] );
+
+class Ecommerce_Header_Plugin {
+    /**
+     * Track if the header has already been rendered.
+     *
+     * @var bool
+     */
+    private $rendered = false;
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+        add_action( 'init', [ $this, 'register_menu_location' ] );
+        add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'wp_body_open', [ $this, 'render_header' ] );
+        add_action( 'template_redirect', [ $this, 'maybe_attach_legacy_hook' ] );
+        add_action( 'wp_ajax_echp_cart_count', [ $this, 'ajax_cart_count' ] );
+        add_action( 'wp_ajax_nopriv_echp_cart_count', [ $this, 'ajax_cart_count' ] );
+    }
+
+    /**
+     * Enqueue frontend assets.
+     */
+    public function enqueue_assets() {
+        wp_enqueue_style( 'echp-header', ECHP_PLUGIN_URL . 'assets/css/header.css', [], ECHP_VERSION );
+        wp_enqueue_script( 'echp-header', ECHP_PLUGIN_URL . 'assets/js/header.js', [], ECHP_VERSION, true );
+
+        wp_localize_script(
+            'echp-header',
+            'echpHeader',
+            [
+                'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            ]
+        );
+    }
+
+    /**
+     * Load plugin text domain.
+     */
+    public function load_textdomain() {
+        load_plugin_textdomain( 'ecommerce-header-suite', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    /**
+     * Ajax handler for retrieving cart count.
+     */
+    public function ajax_cart_count() {
+        wp_send_json_success(
+            [
+                'count' => $this->get_cart_count(),
+            ]
+        );
+    }
+
+    /**
+     * Runs on plugin activation.
+     */
+    public static function activate() {
+        $default = self::get_default_options();
+        $saved   = get_option( 'echp_options', [] );
+
+        update_option( 'echp_options', wp_parse_args( $saved, $default ) );
+    }
+
+    /**
+     * Returns default options.
+     *
+     * @return array
+     */
+    public static function get_default_options() {
+        return [
+            'logo_url'     => '',
+            'cta_label'    => __( 'Ofertas', 'ecommerce-header-suite' ),
+            'cta_link'     => home_url( '/shop' ),
+            'support_text' => __( 'Envío gratis en pedidos superiores a $50', 'ecommerce-header-suite' ),
+            'show_search'  => 1,
+            'show_account' => 1,
+            'show_cart'    => 1,
+        ];
+    }
+
+    /**
+     * Register header menu location.
+     */
+    public function register_menu_location() {
+        register_nav_menu( 'echp_header_menu', __( 'Menú encabezado e-commerce', 'ecommerce-header-suite' ) );
+    }
+
+    /**
+     * Register settings page under Appearance menu.
+     */
+    public function register_settings_page() {
+        add_theme_page(
+            __( 'Encabezado E-commerce', 'ecommerce-header-suite' ),
+            __( 'Encabezado E-commerce', 'ecommerce-header-suite' ),
+            'manage_options',
+            'echp-settings',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public function register_settings() {
+        register_setting( 'echp_settings', 'echp_options', [ $this, 'sanitize_options' ] );
+
+        add_settings_section(
+            'echp_settings_general',
+            __( 'Ajustes generales', 'ecommerce-header-suite' ),
+            function () {
+                echo '<p>' . esc_html__( 'Personaliza los elementos que aparecerán en el encabezado.', 'ecommerce-header-suite' ) . '</p>';
+            },
+            'echp-settings'
+        );
+
+        add_settings_field(
+            'echp_logo_url',
+            __( 'URL del logo', 'ecommerce-header-suite' ),
+            [ $this, 'field_logo_url' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_cta_label',
+            __( 'Texto del botón principal', 'ecommerce-header-suite' ),
+            [ $this, 'field_cta_label' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_cta_link',
+            __( 'Enlace del botón principal', 'ecommerce-header-suite' ),
+            [ $this, 'field_cta_link' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_support_text',
+            __( 'Texto informativo', 'ecommerce-header-suite' ),
+            [ $this, 'field_support_text' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_show_search',
+            __( 'Mostrar buscador', 'ecommerce-header-suite' ),
+            [ $this, 'field_show_search' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_show_account',
+            __( 'Mostrar acceso a cuenta', 'ecommerce-header-suite' ),
+            [ $this, 'field_show_account' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+
+        add_settings_field(
+            'echp_show_cart',
+            __( 'Mostrar resumen de carrito', 'ecommerce-header-suite' ),
+            [ $this, 'field_show_cart' ],
+            'echp-settings',
+            'echp_settings_general'
+        );
+    }
+
+    /**
+     * Sanitize options before saving.
+     *
+     * @param array $input Incoming values.
+     *
+     * @return array
+     */
+    public function sanitize_options( $input ) {
+        $defaults = self::get_default_options();
+        $output   = $defaults;
+
+        $output['logo_url']     = isset( $input['logo_url'] ) ? esc_url_raw( $input['logo_url'] ) : $defaults['logo_url'];
+        $output['cta_label']    = isset( $input['cta_label'] ) ? sanitize_text_field( $input['cta_label'] ) : $defaults['cta_label'];
+        $output['cta_link']     = isset( $input['cta_link'] ) ? esc_url_raw( $input['cta_link'] ) : $defaults['cta_link'];
+        $output['support_text'] = isset( $input['support_text'] ) ? sanitize_text_field( $input['support_text'] ) : $defaults['support_text'];
+        $output['show_search']  = empty( $input['show_search'] ) ? 0 : 1;
+        $output['show_account'] = empty( $input['show_account'] ) ? 0 : 1;
+        $output['show_cart']    = empty( $input['show_cart'] ) ? 0 : 1;
+
+        return $output;
+    }
+
+    /**
+     * Render the settings page.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $options = $this->get_options();
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Encabezado E-commerce', 'ecommerce-header-suite' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'echp_settings' );
+                do_settings_sections( 'echp-settings' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render header output on front-end.
+     */
+    public function render_header() {
+        if ( $this->rendered ) {
+            return;
+        }
+
+        $this->rendered = true;
+
+        $options = $this->get_options();
+
+        $cta_label = $options['cta_label'];
+        $cta_link  = $options['cta_link'];
+        $logo_url  = $options['logo_url'];
+        $support   = $options['support_text'];
+
+        $account_url  = function_exists( 'wc_get_page_permalink' ) ? wc_get_page_permalink( 'myaccount' ) : wp_login_url();
+        $cart_url     = function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : '#';
+        $cart_count   = $this->get_cart_count();
+        $show_top_bar = ! empty( $support ) || $options['show_account'];
+
+        $has_menu = has_nav_menu( 'echp_header_menu' );
+
+        ?>
+        <header class="echp-header" role="banner">
+            <?php if ( $show_top_bar ) : ?>
+                <div class="echp-top-bar">
+                    <?php if ( ! empty( $support ) ) : ?>
+                        <span class="echp-support-text"><?php echo esc_html( $support ); ?></span>
+                    <?php endif; ?>
+                    <?php if ( $options['show_account'] ) : ?>
+                        <a class="echp-account-link" href="<?php echo esc_url( $account_url ); ?>">
+                            <?php esc_html_e( 'Mi cuenta', 'ecommerce-header-suite' ); ?>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            <?php endif; ?>
+            <div class="echp-main-bar">
+                <div class="echp-branding">
+                    <?php if ( ! empty( $logo_url ) ) : ?>
+                        <a class="echp-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+                            <img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php esc_attr_e( 'Logo', 'ecommerce-header-suite' ); ?>" />
+                        </a>
+                    <?php else : ?>
+                        <a class="echp-site-title" href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
+                    <?php endif; ?>
+                </div>
+                <?php if ( $options['show_search'] ) : ?>
+                    <div class="echp-search">
+                        <?php get_search_form(); ?>
+                    </div>
+                <?php endif; ?>
+                <div class="echp-actions">
+                    <a class="echp-cta" href="<?php echo esc_url( $cta_link ); ?>"><?php echo esc_html( $cta_label ); ?></a>
+                    <?php if ( $options['show_cart'] ) : ?>
+                        <a class="echp-cart" href="<?php echo esc_url( $cart_url ); ?>" aria-label="<?php esc_attr_e( 'Ver carrito', 'ecommerce-header-suite' ); ?>">
+                            <span class="echp-cart-icon" aria-hidden="true"></span>
+                            <span class="echp-cart-count" data-echp-cart-count><?php echo esc_html( $cart_count ); ?></span>
+                        </a>
+                    <?php endif; ?>
+                </div>
+                <?php if ( $has_menu ) : ?>
+                    <button class="echp-menu-toggle" type="button" aria-expanded="false" aria-controls="echp-main-navigation">
+                        <span class="echp-menu-toggle-icon" aria-hidden="true"></span>
+                        <span class="screen-reader-text"><?php esc_html_e( 'Abrir menú', 'ecommerce-header-suite' ); ?></span>
+                    </button>
+                <?php endif; ?>
+            </div>
+            <nav id="echp-main-navigation" class="echp-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Menú principal', 'ecommerce-header-suite' ); ?>">
+                <?php
+                if ( $has_menu ) {
+                    wp_nav_menu(
+                        [
+                            'theme_location' => 'echp_header_menu',
+                            'container'      => false,
+                            'menu_class'     => 'echp-menu',
+                            'menu_id'        => 'echp-menu-list',
+                            'fallback_cb'    => false,
+                        ]
+                    );
+                } else {
+                    echo '<ul class="echp-menu"><li>' . esc_html__( 'Asigna un menú al "Menú encabezado e-commerce" desde Apariencia > Menús.', 'ecommerce-header-suite' ) . '</li></ul>';
+                }
+                ?>
+            </nav>
+        </header>
+        <?php
+    }
+
+    /**
+     * Attach header for themes without wp_body_open.
+     */
+    public function maybe_attach_legacy_hook() {
+        if ( did_action( 'wp_body_open' ) ) {
+            return;
+        }
+
+        add_action( 'wp_footer', [ $this, 'render_header' ], 5 );
+    }
+
+    /**
+     * Retrieve stored options merged with defaults.
+     *
+     * @return array
+     */
+    private function get_options() {
+        return wp_parse_args( get_option( 'echp_options', [] ), self::get_default_options() );
+    }
+
+    /**
+     * Return WooCommerce cart item count.
+     *
+     * @return int
+     */
+    private function get_cart_count() {
+        if ( class_exists( 'WooCommerce' ) && function_exists( 'WC' ) ) {
+            $cart = WC()->cart;
+            if ( $cart ) {
+                return (int) $cart->get_cart_contents_count();
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Field: logo URL.
+     */
+    public function field_logo_url() {
+        $options = $this->get_options();
+        ?>
+        <input type="url" class="regular-text" name="echp_options[logo_url]" value="<?php echo esc_attr( $options['logo_url'] ); ?>" placeholder="https://..." />
+        <p class="description"><?php esc_html_e( 'Enlace directo a la imagen del logo.', 'ecommerce-header-suite' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Field: CTA label.
+     */
+    public function field_cta_label() {
+        $options = $this->get_options();
+        ?>
+        <input type="text" class="regular-text" name="echp_options[cta_label]" value="<?php echo esc_attr( $options['cta_label'] ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: CTA link.
+     */
+    public function field_cta_link() {
+        $options = $this->get_options();
+        ?>
+        <input type="url" class="regular-text" name="echp_options[cta_link]" value="<?php echo esc_attr( $options['cta_link'] ); ?>" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: Support text.
+     */
+    public function field_support_text() {
+        $options = $this->get_options();
+        ?>
+        <input type="text" class="regular-text" name="echp_options[support_text]" value="<?php echo esc_attr( $options['support_text'] ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: show search.
+     */
+    public function field_show_search() {
+        $options = $this->get_options();
+        ?>
+        <label>
+            <input type="checkbox" name="echp_options[show_search]" value="1" <?php checked( $options['show_search'], 1 ); ?> />
+            <?php esc_html_e( 'Activar formulario de búsqueda en el encabezado.', 'ecommerce-header-suite' ); ?>
+        </label>
+        <?php
+    }
+
+    /**
+     * Field: show account link.
+     */
+    public function field_show_account() {
+        $options = $this->get_options();
+        ?>
+        <label>
+            <input type="checkbox" name="echp_options[show_account]" value="1" <?php checked( $options['show_account'], 1 ); ?> />
+            <?php esc_html_e( 'Mostrar enlace a la cuenta del cliente.', 'ecommerce-header-suite' ); ?>
+        </label>
+        <?php
+    }
+
+    /**
+     * Field: show cart link.
+     */
+    public function field_show_cart() {
+        $options = $this->get_options();
+        ?>
+        <label>
+            <input type="checkbox" name="echp_options[show_cart]" value="1" <?php checked( $options['show_cart'], 1 ); ?> />
+            <?php esc_html_e( 'Mostrar enlace al carrito con cantidad de productos.', 'ecommerce-header-suite' ); ?>
+        </label>
+        <?php
+    }
+}
+
+new Ecommerce_Header_Plugin();


### PR DESCRIPTION
## Summary
- add a new WordPress plugin that renders a customizable e-commerce header with logo, CTA, search, account access, and cart summary
- create responsive CSS and JavaScript assets with a mobile menu toggle and WooCommerce-aware cart badge refresh
- document installation, configuration, and customization options for the plugin

## Testing
- php -l ecommerce-header/ecommerce-header.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136a57131c8323954916aa1ff2e78c)