### PR TITLE
Agregar widget flotante de WhatsApp configurable para Fertisem

### DIFF
--- a/ecommerce-header/README.md
+++ b/ecommerce-header/README.md
@@ -9,6 +9,7 @@ Plugin de WordPress que añade un encabezado moderno pensado para tiendas en lí
 - Estilos responsive listos para dispositivos móviles.
 - Botón hamburguesa con JavaScript ligero para mostrar/ocultar el menú en pantallas pequeñas.
 - Integración con WooCommerce para mostrar la cantidad de productos en el carrito y actualizarla tras añadir productos mediante AJAX.
+- Botón flotante de WhatsApp configurable con múltiples personas de contacto para Fertisem.
 
 ## Instalación
 
@@ -23,6 +24,7 @@ Plugin de WordPress que añade un encabezado moderno pensado para tiendas en lí
 - **Botón principal**: establece el texto y la URL que apuntará a tus promociones o categorías más rentables.
 - **Mensaje superior**: comparte beneficios de envío, horarios o contacto.
 - **Elementos opcionales**: activa o desactiva buscador, enlace de cuenta y resumen de carrito según las necesidades de tu tienda.
+- **WhatsApp flotante**: define el título, la descripción, la posición del botón y una lista de personas con su teléfono y mensaje personalizado.
 
 ## Hooks personalizados
 

--- a/ecommerce-header/assets/css/header.css
+++ b/ecommerce-header/assets/css/header.css
@@ -20,6 +20,130 @@
     z-index: 999;
 }
 
+.echp-whatsapp {
+    position: fixed;
+    bottom: 1.5rem;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.echp-whatsapp--left {
+    left: 1.5rem;
+    align-items: flex-start;
+}
+
+.echp-whatsapp--right {
+    right: 1.5rem;
+}
+
+.echp-whatsapp__toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.2rem;
+    border-radius: 999px;
+    border: none;
+    background: #25d366;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.echp-whatsapp__toggle:focus-visible {
+    outline: 2px solid #0f172a;
+    outline-offset: 2px;
+}
+
+.echp-whatsapp__icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    background: #ffffff;
+    position: relative;
+}
+
+.echp-whatsapp__icon::after {
+    content: "";
+    position: absolute;
+    inset: 0.35rem;
+    border-radius: 50%;
+    background: #25d366;
+}
+
+.echp-whatsapp__panel {
+    width: min(320px, 85vw);
+    background: #ffffff;
+    border-radius: 1rem;
+    border: 1px solid var(--echp-border);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.15);
+    padding: 1rem;
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.echp-whatsapp__panel.is-open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.echp-whatsapp__header {
+    margin-bottom: 0.75rem;
+}
+
+.echp-whatsapp__title {
+    font-weight: 700;
+    margin: 0 0 0.25rem;
+}
+
+.echp-whatsapp__description {
+    margin: 0;
+    color: var(--echp-muted);
+    font-size: 0.9rem;
+}
+
+.echp-whatsapp__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.echp-whatsapp__contact {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.75rem;
+    border: 1px solid var(--echp-border);
+    text-decoration: none;
+    color: var(--echp-text);
+    transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.echp-whatsapp__contact:hover,
+.echp-whatsapp__contact:focus {
+    border-color: #25d366;
+    transform: translateY(-1px);
+}
+
+.echp-whatsapp__name {
+    font-weight: 600;
+}
+
+.echp-whatsapp__phone {
+    font-size: 0.85rem;
+    color: var(--echp-muted);
+}
+
 .echp-top-bar {
     display: flex;
     justify-content: space-between;
@@ -328,5 +452,22 @@
 
     .echp-menu {
         padding: 0;
+    }
+
+    .echp-whatsapp {
+        bottom: 1rem;
+    }
+
+    .echp-whatsapp--left {
+        left: 1rem;
+    }
+
+    .echp-whatsapp--right {
+        right: 1rem;
+    }
+
+    .echp-whatsapp__toggle {
+        padding: 0.65rem 0.9rem;
+        font-size: 0.9rem;
     }
 }

--- a/ecommerce-header/assets/js/header.js
+++ b/ecommerce-header/assets/js/header.js
@@ -21,6 +21,38 @@
         });
     }
 
+    function toggleWhatsappPanel() {
+        var toggle = document.querySelector('[data-echp-whatsapp-toggle]');
+        var panel = document.querySelector('[data-echp-whatsapp-panel]');
+
+        if (!toggle || !panel) {
+            return;
+        }
+
+        function setState(isOpen) {
+            panel.classList.toggle('is-open', isOpen);
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            panel.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        }
+
+        toggle.addEventListener('click', function () {
+            var isOpen = panel.classList.contains('is-open');
+            setState(!isOpen);
+        });
+
+        document.addEventListener('click', function (event) {
+            if (!panel.classList.contains('is-open')) {
+                return;
+            }
+
+            if (event.target.closest('[data-echp-whatsapp]')) {
+                return;
+            }
+
+            setState(false);
+        });
+    }
+
     function updateCartCount(count) {
         var el = document.querySelector('[data-echp-cart-count]');
         if (!el) {
@@ -78,6 +110,7 @@
 
     ready(function () {
         toggleMenu();
+        toggleWhatsappPanel();
         bindCartEvents();
         requestCartCount();
     });

--- a/ecommerce-header/ecommerce-header.php
+++ b/ecommerce-header/ecommerce-header.php
@@ -37,6 +37,7 @@ class Ecommerce_Header_Plugin {
         add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
         add_action( 'wp_body_open', [ $this, 'render_header' ] );
         add_action( 'template_redirect', [ $this, 'maybe_attach_legacy_hook' ] );
+        add_action( 'wp_footer', [ $this, 'render_whatsapp_widget' ] );
         add_action( 'wp_ajax_echp_cart_count', [ $this, 'ajax_cart_count' ] );
         add_action( 'wp_ajax_nopriv_echp_cart_count', [ $this, 'ajax_cart_count' ] );
     }
@@ -99,6 +100,12 @@ class Ecommerce_Header_Plugin {
             'show_search'  => 1,
             'show_account' => 1,
             'show_cart'    => 1,
+            'whatsapp_enabled'      => 1,
+            'whatsapp_title'        => __( 'Habla con Fertisem', 'ecommerce-header-suite' ),
+            'whatsapp_description'  => __( 'Elige a la persona indicada para ayudarte.', 'ecommerce-header-suite' ),
+            'whatsapp_button_label' => __( 'WhatsApp', 'ecommerce-header-suite' ),
+            'whatsapp_position'     => 'right',
+            'whatsapp_contacts'     => "Ventas|+51999999999|Hola, quiero cotizar\nSoporte|+51999999998|Necesito ayuda con mi pedido",
         ];
     }
 
@@ -192,6 +199,63 @@ class Ecommerce_Header_Plugin {
             'echp-settings',
             'echp_settings_general'
         );
+
+        add_settings_section(
+            'echp_settings_whatsapp',
+            __( 'WhatsApp flotante', 'ecommerce-header-suite' ),
+            function () {
+                echo '<p>' . esc_html__( 'Configura el botón flotante de WhatsApp para Fertisem con varias personas de contacto.', 'ecommerce-header-suite' ) . '</p>';
+            },
+            'echp-settings'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_enabled',
+            __( 'Activar botón flotante', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_enabled' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_title',
+            __( 'Título del panel', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_title' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_description',
+            __( 'Descripción corta', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_description' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_button_label',
+            __( 'Etiqueta del botón', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_button_label' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_position',
+            __( 'Posición del botón', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_position' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
+
+        add_settings_field(
+            'echp_whatsapp_contacts',
+            __( 'Personas de contacto', 'ecommerce-header-suite' ),
+            [ $this, 'field_whatsapp_contacts' ],
+            'echp-settings',
+            'echp_settings_whatsapp'
+        );
     }
 
     /**
@@ -212,6 +276,14 @@ class Ecommerce_Header_Plugin {
         $output['show_search']  = empty( $input['show_search'] ) ? 0 : 1;
         $output['show_account'] = empty( $input['show_account'] ) ? 0 : 1;
         $output['show_cart']    = empty( $input['show_cart'] ) ? 0 : 1;
+        $output['whatsapp_enabled']      = empty( $input['whatsapp_enabled'] ) ? 0 : 1;
+        $output['whatsapp_title']        = isset( $input['whatsapp_title'] ) ? sanitize_text_field( $input['whatsapp_title'] ) : $defaults['whatsapp_title'];
+        $output['whatsapp_description']  = isset( $input['whatsapp_description'] ) ? sanitize_text_field( $input['whatsapp_description'] ) : $defaults['whatsapp_description'];
+        $output['whatsapp_button_label'] = isset( $input['whatsapp_button_label'] ) ? sanitize_text_field( $input['whatsapp_button_label'] ) : $defaults['whatsapp_button_label'];
+        $output['whatsapp_position']     = isset( $input['whatsapp_position'] ) && in_array( $input['whatsapp_position'], [ 'left', 'right' ], true )
+            ? $input['whatsapp_position']
+            : $defaults['whatsapp_position'];
+        $output['whatsapp_contacts']     = isset( $input['whatsapp_contacts'] ) ? sanitize_textarea_field( $input['whatsapp_contacts'] ) : $defaults['whatsapp_contacts'];
 
         return $output;
     }
@@ -235,6 +307,51 @@ class Ecommerce_Header_Plugin {
                 submit_button();
                 ?>
             </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Render floating WhatsApp widget.
+     */
+    public function render_whatsapp_widget() {
+        if ( is_admin() ) {
+            return;
+        }
+
+        $options  = $this->get_options();
+        $contacts = $this->parse_whatsapp_contacts( $options['whatsapp_contacts'] );
+
+        if ( empty( $options['whatsapp_enabled'] ) || empty( $contacts ) ) {
+            return;
+        }
+
+        $position_class = $options['whatsapp_position'] === 'left' ? 'echp-whatsapp--left' : 'echp-whatsapp--right';
+        $panel_id       = 'echp-whatsapp-panel';
+        ?>
+        <div class="echp-whatsapp <?php echo esc_attr( $position_class ); ?>" data-echp-whatsapp>
+            <button class="echp-whatsapp__toggle" type="button" aria-expanded="false" aria-controls="<?php echo esc_attr( $panel_id ); ?>" data-echp-whatsapp-toggle>
+                <span class="echp-whatsapp__icon" aria-hidden="true"></span>
+                <span class="echp-whatsapp__label"><?php echo esc_html( $options['whatsapp_button_label'] ); ?></span>
+            </button>
+            <div id="<?php echo esc_attr( $panel_id ); ?>" class="echp-whatsapp__panel" aria-hidden="true" data-echp-whatsapp-panel>
+                <div class="echp-whatsapp__header">
+                    <p class="echp-whatsapp__title"><?php echo esc_html( $options['whatsapp_title'] ); ?></p>
+                    <?php if ( ! empty( $options['whatsapp_description'] ) ) : ?>
+                        <p class="echp-whatsapp__description"><?php echo esc_html( $options['whatsapp_description'] ); ?></p>
+                    <?php endif; ?>
+                </div>
+                <ul class="echp-whatsapp__list">
+                    <?php foreach ( $contacts as $contact ) : ?>
+                        <li>
+                            <a class="echp-whatsapp__contact" href="<?php echo esc_url( $contact['url'] ); ?>" target="_blank" rel="noopener">
+                                <span class="echp-whatsapp__name"><?php echo esc_html( $contact['name'] ); ?></span>
+                                <span class="echp-whatsapp__phone"><?php echo esc_html( $contact['phone_label'] ); ?></span>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
         </div>
         <?php
     }
@@ -366,6 +483,52 @@ class Ecommerce_Header_Plugin {
     }
 
     /**
+     * Parse WhatsApp contacts from textarea input.
+     *
+     * @param string $raw_contacts Raw textarea value.
+     *
+     * @return array
+     */
+    private function parse_whatsapp_contacts( $raw_contacts ) {
+        $contacts = [];
+        $lines    = preg_split( '/\r\n|\r|\n/', (string) $raw_contacts );
+
+        if ( empty( $lines ) ) {
+            return $contacts;
+        }
+
+        foreach ( $lines as $line ) {
+            $line = trim( $line );
+            if ( $line === '' ) {
+                continue;
+            }
+
+            $parts = array_map( 'trim', explode( '|', $line ) );
+            $name  = $parts[0] ?? '';
+            $phone = $parts[1] ?? '';
+            $text  = $parts[2] ?? '';
+
+            $phone_digits = preg_replace( '/\D+/', '', $phone );
+            if ( $phone_digits === '' ) {
+                continue;
+            }
+
+            $url = 'https://wa.me/' . $phone_digits;
+            if ( $text !== '' ) {
+                $url .= '?text=' . rawurlencode( $text );
+            }
+
+            $contacts[] = [
+                'name'        => $name !== '' ? $name : __( 'Asesor', 'ecommerce-header-suite' ),
+                'phone_label' => $phone !== '' ? $phone : $phone_digits,
+                'url'         => $url,
+            ];
+        }
+
+        return $contacts;
+    }
+
+    /**
      * Field: logo URL.
      */
     public function field_logo_url() {
@@ -442,6 +605,75 @@ class Ecommerce_Header_Plugin {
             <input type="checkbox" name="echp_options[show_cart]" value="1" <?php checked( $options['show_cart'], 1 ); ?> />
             <?php esc_html_e( 'Mostrar enlace al carrito con cantidad de productos.', 'ecommerce-header-suite' ); ?>
         </label>
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp enabled.
+     */
+    public function field_whatsapp_enabled() {
+        $options = $this->get_options();
+        ?>
+        <label>
+            <input type="checkbox" name="echp_options[whatsapp_enabled]" value="1" <?php checked( $options['whatsapp_enabled'], 1 ); ?> />
+            <?php esc_html_e( 'Mostrar el botón flotante de WhatsApp.', 'ecommerce-header-suite' ); ?>
+        </label>
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp title.
+     */
+    public function field_whatsapp_title() {
+        $options = $this->get_options();
+        ?>
+        <input type="text" class="regular-text" name="echp_options[whatsapp_title]" value="<?php echo esc_attr( $options['whatsapp_title'] ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp description.
+     */
+    public function field_whatsapp_description() {
+        $options = $this->get_options();
+        ?>
+        <input type="text" class="regular-text" name="echp_options[whatsapp_description]" value="<?php echo esc_attr( $options['whatsapp_description'] ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp button label.
+     */
+    public function field_whatsapp_button_label() {
+        $options = $this->get_options();
+        ?>
+        <input type="text" class="regular-text" name="echp_options[whatsapp_button_label]" value="<?php echo esc_attr( $options['whatsapp_button_label'] ); ?>" />
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp position.
+     */
+    public function field_whatsapp_position() {
+        $options = $this->get_options();
+        ?>
+        <select name="echp_options[whatsapp_position]">
+            <option value="right" <?php selected( $options['whatsapp_position'], 'right' ); ?>><?php esc_html_e( 'Derecha', 'ecommerce-header-suite' ); ?></option>
+            <option value="left" <?php selected( $options['whatsapp_position'], 'left' ); ?>><?php esc_html_e( 'Izquierda', 'ecommerce-header-suite' ); ?></option>
+        </select>
+        <?php
+    }
+
+    /**
+     * Field: WhatsApp contacts.
+     */
+    public function field_whatsapp_contacts() {
+        $options = $this->get_options();
+        ?>
+        <textarea class="large-text" rows="5" name="echp_options[whatsapp_contacts]" placeholder="Nombre|+51999999999|Mensaje personalizado"><?php echo esc_textarea( $options['whatsapp_contacts'] ); ?></textarea>
+        <p class="description">
+            <?php esc_html_e( 'Una persona por línea. Formato: Nombre|Teléfono|Mensaje opcional.', 'ecommerce-header-suite' ); ?>
+        </p>
         <?php
     }
 }


### PR DESCRIPTION
### Motivation

- Añadir un botón flotante de WhatsApp al plugin de encabezado para permitir contacto directo con varias personas (caso de uso: Fertisem). 

### Description

- Se añadió el renderizado del widget flotante mediante `render_whatsapp_widget` enganchado a `wp_footer` y nuevas opciones por defecto en `get_default_options` para habilitar y configurar el widget. 
- Se incorporaron campos de configuración en la página de ajustes (`register_settings`) y funciones de formulario/guardado (`sanitize_options` y campos `field_whatsapp_*`) para título, descripción, etiqueta del botón, posición y lista de contactos. 
- Se añadió `parse_whatsapp_contacts` para procesar líneas en formato `Nombre|Teléfono|Mensaje` y generar enlaces `https://wa.me/...` con `rawurlencode` del mensaje, evitando números inválidos. 
- Se agregó CSS (`assets/css/header.css`) para estilo y comportamiento responsive del widget y JS (`assets/js/header.js`) para control de apertura/cierre del panel y cierre al hacer clic fuera; además se actualizó el `README.md` con la nueva funcionalidad. 

### Testing

- No se ejecutaron pruebas automatizadas sobre el código modificado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b6db572ac8323bba6eeacc592baa8)